### PR TITLE
Fix quoting in execution of external command from make on Windows.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) `"${R_HOME}/bin/Rscript" -e "RcppParallel::LdFlags()"`
+PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::LdFlags()")
 
 PKG_CXXFLAGS= $(SHLIB_OPENMP_CXXFLAGS)
 


### PR DESCRIPTION
This fix make the package build again on Windows. Without it, it fails while linking because the path to libraries from RcppParallel includes double quotes by accident (```-L"C:/r_packages/pkgbuild/lib/RcppParallel/libs/x64"```). On  Windows `$(shell)` is the generally preferred, more reliable way to execute external process from GNU make.